### PR TITLE
Edge blending shift

### DIFF
--- a/include/Warp.h
+++ b/include/Warp.h
@@ -159,6 +159,24 @@ class Warp : public std::enable_shared_from_this<Warp> {
 		mEdges.z = glm::clamp( edges.z * 0.5f, 0.0f, 1.0f );
 		mEdges.w = glm::clamp( edges.w * 0.5f, 0.0f, 1.0f );
 	}
+	//! returns the edge blending shift value for the left, top, right and bottom (values between -1 and 1)
+	virtual const ci::vec4 getShift() const { return mShift; }
+	//! set the edge blending shift value for the left, top, right and bottom (values between -1 and 1)
+	virtual void setShift(float left, float top, float right, float bottom) 
+	{
+		mShift.x = left;
+		mShift.y = top;
+		mShift.z = right;
+		mShift.w = bottom;
+	}
+	//! set the edge blending shift value for the left, top, right and bottom (values between -1 and 1)
+	virtual void setShift(const ci::vec4 &shift)
+	{
+		mShift.x = shift.x;
+		mShift.y = shift.y;
+		mShift.z = shift.z;
+		mShift.w = shift.w;
+	}
 
 	//! reset control points to undistorted image
 	virtual void reset() = 0;
@@ -267,7 +285,7 @@ class Warp : public std::enable_shared_from_this<Warp> {
 	ci::vec3 mGamma;
 	ci::vec4 mEdges;
 	float    mExponent;
-
+	ci::vec4 mShift;
 	//! time of last control point selection
 	double mSelectedTime;
 	//! keep track of mouse position

--- a/src/Warp.cpp
+++ b/src/Warp.cpp
@@ -180,12 +180,12 @@ XmlTree Warp::toXml() const
 		blend.push_back( luminance );
 
 		XmlTree shift;
-		edges.setTag("shift");
-		edges.setAttribute("left", mShift.x);
-		edges.setAttribute("top", mShift.y);
-		edges.setAttribute("right", mShift.z);
-		edges.setAttribute("bottom", mShift.w);
-		blend.push_back(edges);
+		shift.setTag("shift");
+		shift.setAttribute("left", mShift.x);
+		shift.setAttribute("top", mShift.y);
+		shift.setAttribute("right", mShift.z);
+		shift.setAttribute("bottom", mShift.w);
+		blend.push_back(shift);
 	}
 	xml.push_back( blend );
 

--- a/src/Warp.cpp
+++ b/src/Warp.cpp
@@ -47,6 +47,7 @@ Warp::Warp( WarpType type )
     , mGamma( 1.0f )
     , mEdges( 0.0f )
     , mExponent( 2.0f )
+	, mShift( 0.0f )
     , mSelectedTime( 0 )
 {
 	mWindowSize = vec2( float( mWidth ), float( mHeight ) );
@@ -177,6 +178,14 @@ XmlTree Warp::toXml() const
 		luminance.setAttribute( "green", mLuminance.y );
 		luminance.setAttribute( "blue", mLuminance.z );
 		blend.push_back( luminance );
+
+		XmlTree shift;
+		edges.setTag("shift");
+		edges.setAttribute("left", mShift.x);
+		edges.setAttribute("top", mShift.y);
+		edges.setAttribute("right", mShift.z);
+		edges.setAttribute("bottom", mShift.w);
+		blend.push_back(edges);
 	}
 	xml.push_back( blend );
 
@@ -222,6 +231,14 @@ void Warp::fromXml( const XmlTree &xml )
 			mLuminance.x = luminance->getAttributeValue<float>( "red", mLuminance.x );
 			mLuminance.y = luminance->getAttributeValue<float>( "green", mLuminance.y );
 			mLuminance.z = luminance->getAttributeValue<float>( "blue", mLuminance.z );
+		}
+
+		auto shift = blend->find("shift");
+		if (shift != blend->end()) {
+			mShift.x = shift->getAttributeValue<float>("left", mShift.x);
+			mShift.y = shift->getAttributeValue<float>("top", mShift.y);
+			mShift.z = shift->getAttributeValue<float>("right", mShift.z);
+			mShift.w = shift->getAttributeValue<float>("bottom", mShift.w);
 		}
 	}
 
@@ -274,7 +291,7 @@ void Warp::deselectControlPoint()
 
 unsigned Warp::findControlPoint( const vec2 &pos, float *distance ) const
 {
-	unsigned index;
+	unsigned index = 0;
 
 	// store mouse position for later use in e.g. WarpBilinear::keyDown().
 	mMouse = pos;
@@ -352,6 +369,7 @@ WarpList Warp::readSettings( const DataSourceRef &source )
 
 		// iterate maps
 		for( XmlTree::ConstIter child = profileXml.begin( "map" ); child != profileXml.end(); ++child ) {
+
 			XmlTree warpXml = child->getChild( "warp" );
 
 			// create warp of the correct type

--- a/src/WarpBilinear.cpp
+++ b/src/WarpBilinear.cpp
@@ -193,7 +193,8 @@ void WarpBilinear::draw( bool controls )
 	mShader->uniform( "uEdges", mEdges );
 	mShader->uniform( "uExponent", mExponent );
 	mShader->uniform( "uEditMode", (bool)isEditModeEnabled() );
-	mShader->uniform("uShift", mShift);
+	mShader->uniform( "uShift", mShift + vec4(-mX1, -mY1, 1.f - mX2, 1.f - mY2) );
+	
 
 	mBatch->draw();
 

--- a/src/WarpBilinear.cpp
+++ b/src/WarpBilinear.cpp
@@ -193,6 +193,7 @@ void WarpBilinear::draw( bool controls )
 	mShader->uniform( "uEdges", mEdges );
 	mShader->uniform( "uExponent", mExponent );
 	mShader->uniform( "uEditMode", (bool)isEditModeEnabled() );
+	mShader->uniform("uShift", mShift);
 
 	mBatch->draw();
 
@@ -689,6 +690,7 @@ void WarpBilinear::createShader()
 	    "uniform vec4  uEdges;\n"
 	    "uniform float uExponent;\n"
 	    "uniform bool  uEditMode;\n"
+		"uniform vec4 uShift;\n"
 	    ""
 	    "in vec2 vertTexCoord0;\n"
 	    "in vec4 vertColor;\n"
@@ -706,10 +708,10 @@ void WarpBilinear::createShader()
 	    "	vec4 texColor = texture( uTex0, vertTexCoord0 );\n"
 	    ""
 	    "	float a = 1.0;\n"
-	    "	if( uEdges.x > 0.0 ) a *= clamp( vertTexCoord0.x / uEdges.x, 0.0, 1.0 );\n"
-	    "	if( uEdges.y > 0.0 ) a *= clamp( vertTexCoord0.y / uEdges.y, 0.0, 1.0 );\n"
-	    "	if( uEdges.z > 0.0 ) a *= clamp( ( 1.0 - vertTexCoord0.x ) / uEdges.z, 0.0, 1.0 );\n"
-	    "	if( uEdges.w > 0.0 ) a *= clamp( ( 1.0 - vertTexCoord0.y ) / uEdges.w, 0.0, 1.0 );\n"
+		"	if( uEdges.x > 0.0 ) a *= clamp( ( uShift.x + vertTexCoord0.x ) / uEdges.x, 0.0, 1.0 );\n"
+		"	if( uEdges.y > 0.0 ) a *= clamp( ( uShift.y + vertTexCoord0.y ) / uEdges.y, 0.0, 1.0 );\n"
+	    "	if( uEdges.z > 0.0 ) a *= clamp( ( 1.0 - uShift.z - vertTexCoord0.x ) / uEdges.z, 0.0, 1.0 );\n"
+	    "	if( uEdges.w > 0.0 ) a *= clamp( ( 1.0 - uShift.w - vertTexCoord0.y ) / uEdges.w, 0.0, 1.0 );\n"
 	    ""
 	    "	const vec3 one = vec3( 1.0 );\n"
 	    "	vec3 blend = ( a < 0.5 ) ? ( uLuminance * pow( 2.0 * a, uExponent ) ) : one - ( one - uLuminance ) * pow( 2.0 * ( 1.0 - a ), uExponent );\n"

--- a/src/WarpPerspective.cpp
+++ b/src/WarpPerspective.cpp
@@ -333,7 +333,7 @@ void WarpPerspective::createShader()
 	    "uniform vec3 uGamma;\n"
 	    "uniform vec4  uEdges;\n"
 	    "uniform float uExponent;\n"
-		"uniform vec3 uShift;\n"
+		"uniform vec4 uShift;\n"
 	    ""
 	    "in vec2 vertTexCoord0;\n"
 	    "in vec4 vertColor;\n"

--- a/src/WarpPerspective.cpp
+++ b/src/WarpPerspective.cpp
@@ -121,7 +121,7 @@ void WarpPerspective::draw( const gl::Texture2dRef &texture, const Area &srcArea
 	mShader->uniform( "uGamma", mGamma );
 	mShader->uniform( "uEdges", mEdges );
 	mShader->uniform( "uExponent", mExponent );
-
+	mShader->uniform("uShift", mShift);
 	auto coords = texture->getAreaTexCoords( srcArea );
 	gl::drawSolidRect( rect, coords.getUpperLeft(), coords.getLowerRight() );
 
@@ -333,6 +333,7 @@ void WarpPerspective::createShader()
 	    "uniform vec3 uGamma;\n"
 	    "uniform vec4  uEdges;\n"
 	    "uniform float uExponent;\n"
+		"uniform vec3 uShift;\n"
 	    ""
 	    "in vec2 vertTexCoord0;\n"
 	    "in vec4 vertColor;\n"
@@ -343,10 +344,10 @@ void WarpPerspective::createShader()
 	    "	vec4 texColor = texture( uTex0, vertTexCoord0 );\n"
 	    ""
 	    "	float a = 1.0;\n"
-	    "	if( uEdges.x > 0.0 ) a *= clamp( vertTexCoord0.x / uEdges.x, 0.0, 1.0 );\n"
-	    "	if( uEdges.y > 0.0 ) a *= clamp( vertTexCoord0.y / uEdges.y, 0.0, 1.0 );\n"
-	    "	if( uEdges.z > 0.0 ) a *= clamp( ( 1.0 - vertTexCoord0.x ) / uEdges.z, 0.0, 1.0 );\n"
-	    "	if( uEdges.w > 0.0 ) a *= clamp( ( 1.0 - vertTexCoord0.y ) / uEdges.w, 0.0, 1.0 );\n"
+		"	if( uEdges.x > 0.0 ) a *= clamp( ( uShift.x + vertTexCoord0.x ) / uEdges.x, 0.0, 1.0 );\n"
+		"	if( uEdges.y > 0.0 ) a *= clamp( ( uShift.y + vertTexCoord0.y ) / uEdges.y, 0.0, 1.0 );\n"
+	    "	if( uEdges.z > 0.0 ) a *= clamp( ( 1.0 - uShift.z - vertTexCoord0.x ) / uEdges.z, 0.0, 1.0 );\n"
+	    "	if( uEdges.w > 0.0 ) a *= clamp( ( 1.0 - uShift.w - vertTexCoord0.y ) / uEdges.w, 0.0, 1.0 );\n"
 	    ""
 	    "	const vec3 one = vec3( 1.0 );\n"
 	    "	vec3 blend = ( a < 0.5 ) ? ( uLuminance * pow( 2.0 * a, uExponent ) ) : one - ( one - uLuminance ) * pow( 2.0 * ( 1.0 - a ), uExponent );\n"


### PR DESCRIPTION
Hello Paul,
I needed to shift edge blending to adjust easily
I added 
`mShader->uniform( "uShift", mShift + vec4(-mX1, -mY1, 1.f - mX2, 1.f - mY2) );
`
because with this code it did not worked with edge 
`warp->draw(texture, m_oSrcArea); 
`	

but with this, It worked !
`warp->begin();
 gl::draw(texture, m_oSrcArea, warp->getBounds());
 warp->end();`
`	

Perhaps we should add this method into WarpPerspective class ?
`void setTexCoords( float x1, float y1, float x2, float y2 );	
`
Thanks for this nice block !