### PR TITLE
Added missing WarpPerspectiveBilinear::resize( ivec2 )

### DIFF
--- a/include/Warp.h
+++ b/include/Warp.h
@@ -512,6 +512,7 @@ class WarpPerspectiveBilinear : public WarpBilinear {
 	void keyDown( ci::app::KeyEvent &event ) override;
 
 	void resize() override;
+	void resize( const ci::ivec2 &size ) override;
 
 	//! Set the width and height of the content in pixels.
 	void setSize( float w, float h ) override;

--- a/src/WarpPerspectiveBilinear.cpp
+++ b/src/WarpPerspectiveBilinear.cpp
@@ -182,6 +182,15 @@ void WarpPerspectiveBilinear::resize()
 	WarpBilinear::resize();
 }
 
+void WarpPerspectiveBilinear::resize( const ivec2 &size )
+{
+	// make content size compatible with WarpBilinear's mWindowSize
+	mWarp->setSize( size );
+
+	mWarp->resize( size );
+	WarpBilinear::resize( size );
+}
+
 void WarpPerspectiveBilinear::setSize( float w, float h )
 {
 	// make content size compatible with WarpBilinear's mWindowSize


### PR DESCRIPTION
`WarpPerspectiveBilinear::resize( ivec2 )` was missing.